### PR TITLE
Get GitHub token form env

### DIFF
--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -358,7 +358,7 @@ def build(
 
 
 def get_github_pat() -> dict[str, str]:
-    """Gets GitHub users and Pat from .gitconfig.
+    """Gets GitHub users and PAT from .gitconfig.
 
     Raises:
         ValueError: If .git-credentials does not exist.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -163,7 +163,7 @@ def test_build(
     mock_install_ipy: Mock, mock_poetry_install: Mock, tmp_path: Path
 ) -> None:
     """Check that build calls poetry_install and install_ipykernel."""
-    build(curr_path=str(tmp_path))
+    build(path=str(tmp_path))
     assert mock_poetry_install.call_count == 1
     assert mock_install_ipy.call_count == 1
 


### PR DESCRIPTION
Enforces team name convention (only contain alphanumeric characters and/or underscores).

Added support for fetching GitHub PAT from .git-credentials.
If the user does not supply GitHub credentials but wants to create a repo, the cli will check for them in .git-credentials. The user can then choose between the GitHub users available.

