### PR TITLE
STAT-135: Improve validity checking of repo names

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,6 @@ ignore = E203,E501,RST201,RST203,RST301,W503,D301,B950
 max-line-length = 80
 max-complexity = 10
 docstring-convention = google
-per-file-ignores = tests/*:S101
+per-file-ignores = tests/*:S101,D103
 rst-roles = class,const,func,meth,mod,ref
 rst-directives = deprecated

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -283,9 +283,9 @@ def create(
     ),
 ) -> None:
     """:sparkles: Skap et prosjekt lokalt og på Github (hvis ønsket).Følger kjent beste praksis i SSB. :sparkles:."""
-    if not contains_only_alnum_underscore(project_name):
+    if not valid_repo_name(project_name):
         raise ValueError(
-            "Team name should only contain alphanumeric characters and/or underscores (e.g test_project)"
+            "Invalid repo name, please choose a name in the form 'my-fantastic-project'"
         )
 
     if add_github and not github_token:
@@ -385,19 +385,22 @@ def get_github_pat() -> dict[str, str]:
     return user_token_dict
 
 
-def contains_only_alnum_underscore(check_str: str) -> bool:
-    """Checks if a string consists of only alphanumeric characters and underscores.
+def valid_repo_name(name: str) -> bool:
+    """Checks if the supplied name is suitable for a git repo.
+
+    Accepts:
+     - ASCII characters upper and lower case
+     - Underscores
+     - Hyphens
+     - 3 characters or longer
 
     Args:
-        check_str: String to check
+        check_str: Supplied repo name
 
     Returns:
-        bool: True if the string contains only  alphanumeric characters and underscores.
+        bool: True if the string is a valid repo name
     """
-    for char in check_str:
-        if not char.isalnum() and char != "_":
-            return False
-    return True
+    return len(name) >= 3 and re.fullmatch("^[a-zA-Z0-9-_]+$", name) is not None
 
 
 def choose_login() -> str:

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -395,7 +395,7 @@ def valid_repo_name(name: str) -> bool:
      - 3 characters or longer
 
     Args:
-        check_str: Supplied repo name
+        name: Supplied repo name
 
     Returns:
         bool: True if the string is a valid repo name

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,11 +24,29 @@ from ssb_project_cli.ssb_project.app import projectname_from_currfolder
 from ssb_project_cli.ssb_project.app import request_name_email
 from ssb_project_cli.ssb_project.app import rm_hyphen_and_underscore
 from ssb_project_cli.ssb_project.app import set_branch_protection_rules
+from ssb_project_cli.ssb_project.app import valid_repo_name
 from ssb_project_cli.ssb_project.app import workspace
 from ssb_project_cli.ssb_project.app import workspace_uri_from_projectname
 
 
 PKG = "ssb_project_cli.ssb_project.app"
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("word", True),
+        ("words-with-hyphens", True),
+        ("words_with_underscores", True),
+        ("non-ascii-$%&", False),
+        ("norwegian-characters-æøå", False),
+        ("words with spaces", False),
+        ("hi", False),
+    ],
+)
+def test_valid_repo_name(name: str, expected: bool):
+    """Checks a range of valid and invalid repo names."""
+    assert valid_repo_name(name) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,7 +44,7 @@ PKG = "ssb_project_cli.ssb_project.app"
         ("hi", False),
     ],
 )
-def test_valid_repo_name(name: str, expected: bool):
+def test_valid_repo_name(name: str, expected: bool) -> None:
     """Checks a range of valid and invalid repo names."""
     assert valid_repo_name(name) == expected
 


### PR DESCRIPTION
Limit to ASCII characters, numbers, underscores, hyphens
