### PR TITLE
Remove virtualenvironment associated with a kernel

### DIFF
--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -670,8 +670,7 @@ def clean_virtual_env(project_name: str) -> None:
 
     typer.echo(f"Removing virtual environment for {project_name}...")
 
-    #find_envs_cmd = f"ls /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
-    find_envs_cmd =  f"ls /Users/damirmedakovic/Library/Caches/pypoetry/virtualenvs/{project_name}*"
+    find_envs_cmd = f"ls /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
 
     poetry_environments_process = subprocess.run(find_envs_cmd, capture_output=True, shell=True) # noqa: S603 no untrusted input
 

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -639,6 +639,9 @@ def clean(
         f"Deleting kernel {project_name}...If you wish to also delete the project files, you can do so manually."
     )
 
+    clean_virtual_env(project_name)
+
+
     clean_cmd = f"jupyter kernelspec remove -f {project_name}".split()
 
     result = subprocess.run(  # noqa: S603 no untrusted input
@@ -660,8 +663,6 @@ def clean(
         exit(1)
 
 
-    clean_virtual_env(project_name)
-
     print(f"Deleted Jupyter kernel {project_name}.")
 
 
@@ -674,7 +675,7 @@ def clean_virtual_env(project_name: str) -> None:
     """
     typer.echo(f"Removing virtual environment for {project_name}...")
 
-    find_envs_cmd = f"ls /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
+    find_envs_cmd = f"ls -d /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
 
     poetry_environments_process = subprocess.run(find_envs_cmd, capture_output=True, shell=True) # noqa: S603 no untrusted input
 
@@ -690,14 +691,8 @@ def clean_virtual_env(project_name: str) -> None:
     else:
         shortest_len = float("inf")
         for line in results: 
-            if line.startswith("/home"):
-                if len(line) < shortest_len:
-                    best_match = line[:-1]
-
-        if best_match == "":
-            typer.echo(f"Could not find a matching virtual enironment for {project_name}")
-            exit(1)
-
+            if len(line) < shortest_len:
+                best_match = line[:-1]
         
         remove_venv_cmd = f"rm -rf {best_match}"
         remove_venv_result = subprocess.run(remove_venv_cmd, capture_output=True, shell=True)

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -540,6 +540,7 @@ def create_error_log(log: str, calling_function: str) -> None:
         typer.echo(f"Error while attempting to write the log file: {e}")
 
 
+
 def poetry_source_add(
     source_url: str, cwd: Path, source_name: str = NEXUS_SOURCE_NAME
 ) -> None:
@@ -658,8 +659,41 @@ def clean(
         create_error_log(log, calling_function)
         exit(1)
 
+
+    clean_virtual_env(project_name)
+
     print(f"Deleted Jupyter kernel {project_name}.")
 
+
+
+def clean_virtual_env(project_name: str) -> None:
+
+    typer.echo(f"Removing virtual environment for {project_name}...")
+
+    #find_envs_cmd = f"ls /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
+    find_envs_cmd =  f"ls /Users/damirmedakovic/Library/Caches/pypoetry/virtualenvs/{project_name}*"
+
+    poetry_environments_process = subprocess.run(find_envs_cmd, capture_output=True, shell=True) # noqa: S603 no untrusted input
+
+    results = poetry_environments_process.stdout.decode("utf-8")
+
+    results = results.splitlines()
+
+    if not results:
+        typer.echo("No virtual environments found for this kernel. It may have been removed manually. Skipping...")
+    else:
+        shortest_len = float("inf")
+        for line in results: 
+            if line.startswith("/"):
+                if len(line) < shortest_len:
+                    best_match = line[:-1]
+        
+        remove_venv_cmd = f"rm -rf {best_match}"
+        subprocess.run(remove_venv_cmd, capture_output=True, shell=True)
+
+        typer.echo(f"Successfully removed virtualenv located at {best_match}")
+
+            
 
 def create_github(
     github_token: str, repo_name: str, repo_privacy: str, repo_description: str

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -667,7 +667,11 @@ def clean(
 
 
 def clean_virtual_env(project_name: str) -> None:
+    """Removes virtual environment associated to a specific project name.
 
+    Args:
+        project_name: The project the virtual environment is associated to. 
+    """
     typer.echo(f"Removing virtual environment for {project_name}...")
 
     find_envs_cmd = f"ls /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
@@ -678,19 +682,30 @@ def clean_virtual_env(project_name: str) -> None:
 
     results = results.splitlines()
 
+    best_match = str()
+
     if not results:
         typer.echo("No virtual environments found for this kernel. It may have been removed manually. Skipping...")
+        exit(1)
     else:
         shortest_len = float("inf")
         for line in results: 
-            if line.startswith("/"):
+            if line.startswith("/home"):
                 if len(line) < shortest_len:
                     best_match = line[:-1]
+
+        if best_match == "":
+            typer.echo(f"Could not find a matching virtual enironment for {project_name}")
+            exit(1)
+
         
         remove_venv_cmd = f"rm -rf {best_match}"
-        subprocess.run(remove_venv_cmd, capture_output=True, shell=True)
+        remove_venv_result = subprocess.run(remove_venv_cmd, capture_output=True, shell=True)
 
-        typer.echo(f"Successfully removed virtualenv located at {best_match}")
+        if remove_venv_result.stderr:
+            typer.echo(f"Something went wrong while removing virtual environment located at {best_match}")
+        else:
+            typer.echo(f"Successfully removed virtualenv located at {best_match}")
 
             
 

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -673,8 +673,8 @@ def clean_virtual_env(project_name: str) -> None:
 
     find_envs_cmd = f"ls -d /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
 
-    poetry_environments_process = subprocess.run(  # noqa: S603 no untrusted input
-        find_envs_cmd, capture_output=True, shell=True
+    poetry_environments_process = subprocess.run(
+        find_envs_cmd, capture_output=True, shell=True  # noqa: S602
     )
 
     results = poetry_environments_process.stdout.decode("utf-8")
@@ -698,7 +698,7 @@ def clean_virtual_env(project_name: str) -> None:
         remove_venv_result = subprocess.run(
             remove_venv_cmd,
             capture_output=True,
-            shell=True,  # noqa: S603 no untrusted input
+            shell=True,  # noqa: S602
         )
 
         if remove_venv_result.stderr:

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -540,7 +540,6 @@ def create_error_log(log: str, calling_function: str) -> None:
         typer.echo(f"Error while attempting to write the log file: {e}")
 
 
-
 def poetry_source_add(
     source_url: str, cwd: Path, source_name: str = NEXUS_SOURCE_NAME
 ) -> None:
@@ -641,7 +640,6 @@ def clean(
 
     clean_virtual_env(project_name)
 
-
     clean_cmd = f"jupyter kernelspec remove -f {project_name}".split()
 
     result = subprocess.run(  # noqa: S603 no untrusted input
@@ -662,47 +660,54 @@ def clean(
         create_error_log(log, calling_function)
         exit(1)
 
-
     print(f"Deleted Jupyter kernel {project_name}.")
-
 
 
 def clean_virtual_env(project_name: str) -> None:
     """Removes virtual environment associated to a specific project name.
 
     Args:
-        project_name: The project the virtual environment is associated to. 
+        project_name: The project the virtual environment is associated to.
     """
     typer.echo(f"Removing virtual environment for {project_name}...")
 
     find_envs_cmd = f"ls -d /home/jovyan/.cache/pypoetry/virtualenvs/{project_name}*"
 
-    poetry_environments_process = subprocess.run(find_envs_cmd, capture_output=True, shell=True) # noqa: S603 no untrusted input
+    poetry_environments_process = subprocess.run(  # noqa: S603 no untrusted input
+        find_envs_cmd, capture_output=True, shell=True
+    )
 
     results = poetry_environments_process.stdout.decode("utf-8")
 
-    results = results.splitlines()
+    results_list = results.splitlines()
 
-    best_match = str()
+    best_match = ""
 
     if not results:
-        typer.echo("No virtual environments found for this kernel. It may have been removed manually. Skipping...")
+        typer.echo(
+            "No virtual environments found for this kernel. It may have been removed manually. Skipping..."
+        )
         exit(1)
     else:
         shortest_len = float("inf")
-        for line in results: 
+        for line in results_list:
             if len(line) < shortest_len:
                 best_match = line[:-1]
-        
+
         remove_venv_cmd = f"rm -rf {best_match}"
-        remove_venv_result = subprocess.run(remove_venv_cmd, capture_output=True, shell=True)
+        remove_venv_result = subprocess.run(
+            remove_venv_cmd,
+            capture_output=True,
+            shell=True,  # noqa: S603 no untrusted input
+        )
 
         if remove_venv_result.stderr:
-            typer.echo(f"Something went wrong while removing virtual environment located at {best_match}")
+            typer.echo(
+                f"Something went wrong while removing virtual environment located at {best_match}"
+            )
         else:
             typer.echo(f"Successfully removed virtualenv located at {best_match}")
 
-            
 
 def create_github(
     github_token: str, repo_name: str, repo_privacy: str, repo_description: str

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,7 @@ from github import GithubException
 from ssb_project_cli.ssb_project.app import NEXUS_SOURCE_NAME
 from ssb_project_cli.ssb_project.app import build
 from ssb_project_cli.ssb_project.app import clean
+from ssb_project_cli.ssb_project.app import clean_virtual_env
 from ssb_project_cli.ssb_project.app import create_github
 from ssb_project_cli.ssb_project.app import create_project_from_template
 from ssb_project_cli.ssb_project.app import extract_name_email
@@ -26,7 +27,6 @@ from ssb_project_cli.ssb_project.app import poetry_source_includes_source_name
 from ssb_project_cli.ssb_project.app import poetry_source_remove
 from ssb_project_cli.ssb_project.app import request_name_email
 from ssb_project_cli.ssb_project.app import running_onprem
-from ssb_project_cli.ssb_project.app import clean_virtual_env
 from ssb_project_cli.ssb_project.app import set_branch_protection_rules
 from ssb_project_cli.ssb_project.app import valid_repo_name
 
@@ -277,7 +277,6 @@ def test_clean(mock_run: Mock, mock_kernels: Mock, mock_confirm: Mock) -> None:
     clean(project_name)
 
     assert mock_run.call_count == 2
-
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -279,8 +279,6 @@ def test_clean(mock_run: Mock, mock_kernels: Mock, mock_confirm: Mock) -> None:
     assert mock_run.call_count == 2
 
 
-@test_clean_virtual_env()
-
 
 @pytest.mark.parametrize(
     "image_spec,expected_result",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,6 +26,7 @@ from ssb_project_cli.ssb_project.app import poetry_source_includes_source_name
 from ssb_project_cli.ssb_project.app import poetry_source_remove
 from ssb_project_cli.ssb_project.app import request_name_email
 from ssb_project_cli.ssb_project.app import running_onprem
+from ssb_project_cli.ssb_project.app import clean_virtual_env
 from ssb_project_cli.ssb_project.app import set_branch_protection_rules
 from ssb_project_cli.ssb_project.app import valid_repo_name
 
@@ -276,6 +277,9 @@ def test_clean(mock_run: Mock, mock_kernels: Mock, mock_confirm: Mock) -> None:
     clean(project_name)
 
     assert mock_run.call_count == 2
+
+
+@test_clean_virtual_env()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
-Completes the clean function by removing associated virtual environment
-Looks in .cache/pypoetry/virtualenvs/ for virtualenvironments with the same name as project
-Projects may be named similarly, so the new function remove_virtualenv deletes the "best match"