### PR TITLE
Stop prompting user when supplied with single GitHub account

### DIFF
--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -516,10 +516,14 @@ def choose_login() -> str:
         str: GitHub personal access token
     """
     user_token_dict: dict[str, str] = get_github_pat()
+
+    if len(user_token_dict) == 1:
+        return list(user_token_dict.values())[0]
     if user_token_dict:
         choice = questionary.select(
             "Select your GitHub account:", choices=user_token_dict.keys()  # type: ignore
         ).ask()
+        print(choice)
         return user_token_dict[choice]
     else:
         pat: str = questionary.password(

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -518,6 +518,7 @@ def choose_login() -> str:
     user_token_dict: dict[str, str] = get_github_pat()
 
     if len(user_token_dict) == 1:
+        print(f"Using GitHub account: {list(user_token_dict.keys())[0]}")
         return list(user_token_dict.values())[0]
     if user_token_dict:
         choice = questionary.select(

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -518,7 +518,6 @@ def choose_login() -> str:
     user_token_dict: dict[str, str] = get_github_pat()
 
     if len(user_token_dict) == 1:
-        print(f"Using GitHub account: {list(user_token_dict.keys())[0]}")
         return list(user_token_dict.values())[0]
     if user_token_dict:
         choice = questionary.select(

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -523,7 +523,6 @@ def choose_login() -> str:
         choice = questionary.select(
             "Select your GitHub account:", choices=user_token_dict.keys()  # type: ignore
         ).ask()
-        print(choice)
         return user_token_dict[choice]
     else:
         pat: str = questionary.password(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -317,7 +317,9 @@ def test_clean(
 @patch(f"{PKG}.Path")
 @patch(f"{PKG}.subprocess.run")
 @patch(f"{PKG}.questionary")
-def test_clean_venv(confirm_mock: Mock, run_mock: Mock, path_mock: Mock, mock_log: Mock) -> None:
+def test_clean_venv(
+    confirm_mock: Mock, run_mock: Mock, path_mock: Mock, mock_log: Mock
+) -> None:
 
     confirm_mock.return_value = True
     path_mock.is_dir.return_value = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -313,10 +313,11 @@ def test_clean(
     assert mock_log.call_count == 1
 
 
+@patch(f"{PKG}.create_error_log")
 @patch(f"{PKG}.Path")
 @patch(f"{PKG}.subprocess.run")
 @patch(f"{PKG}.questionary")
-def test_clean_venv(confirm_mock: Mock, run_mock: Mock, path_mock: Mock) -> None:
+def test_clean_venv(confirm_mock: Mock, run_mock: Mock, path_mock: Mock, mock_log: Mock) -> None:
 
     confirm_mock.return_value = True
     path_mock.is_dir.return_value = True
@@ -325,6 +326,7 @@ def test_clean_venv(confirm_mock: Mock, run_mock: Mock, path_mock: Mock) -> None
         clean_venv()
 
     assert run_mock.call_count == 1
+    assert mock_log.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -421,11 +423,17 @@ def test_get_kernels_dict(mock_run: Mock) -> None:
 
 
 @patch(f"{PKG}.get_github_pat")
-@patch(f"{PKG}.questionary.password")
-def test_prompt_pat(q_password_mock: Mock, mock_get_pat: Mock) -> None:
-    mock_get_pat.return_value = None
-    choose_login()
-    assert q_password_mock.call_count == 1
+@patch(f"{PKG}.questionary")
+def test_prompt_pat(mock_questionary: Mock, mock_get_pat: Mock) -> None:
+    mock_get_pat.return_value = {"user": "pat", "user2": "pat2"}
+    mock_questionary.select().ask.return_value = "user2"
+    assert choose_login() == "pat2"
+
+
+@patch(f"{PKG}.get_github_pat")
+def test_prompt_pat_single_login(mock_get_pat: Mock) -> None:
+    mock_get_pat.return_value = {"user": "pat"}
+    assert choose_login() == "pat"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- User will no longer be prompted to select account when only a single github account is found.
- Add test for new functionality.
- Mocked out the creation of error log in clean_venv test. 