### PR TITLE
Use rich print

### DIFF
--- a/src/ssb_project_cli/ssb_project/build/build.py
+++ b/src/ssb_project_cli/ssb_project/build/build.py
@@ -9,6 +9,7 @@ from .poetry import poetry_install
 from .poetry import poetry_source_add
 from .poetry import poetry_source_includes_source_name
 from .poetry import poetry_source_remove
+from rich import print
 
 
 def build_project(path: str, working_directory: Path) -> None:


### PR DESCRIPTION
Should now print the correct icon instead of :twisted_rightwards_arrows when onprem environment is detected.