### PR TITLE
Pass in argument as string

### DIFF
--- a/src/ssb_project_cli/ssb_project/clean/clean.py
+++ b/src/ssb_project_cli/ssb_project/clean/clean.py
@@ -1,5 +1,4 @@
 """Clean command module."""
-import os
 import subprocess  # noqa: S404
 from pathlib import Path
 
@@ -96,8 +95,7 @@ def clean_venv() -> None:
                 "Please provide the path to the ssb project you wish to delete the virtual environment for:"
             ).ask()
             if Path(f"{path}/.venv").is_dir():
-                curr_path = os.getcwd()
-                clean_venv_cmd = f"rm -rf {curr_path}/{path}/.venv"
+                clean_venv_cmd = f"rm -rf {path}/.venv"
 
                 execute_command(
                     clean_venv_cmd,

--- a/src/ssb_project_cli/ssb_project/clean/clean.py
+++ b/src/ssb_project_cli/ssb_project/clean/clean.py
@@ -1,7 +1,7 @@
 """Clean command module."""
+import os
 import subprocess  # noqa: S404
 from pathlib import Path
-import os
 
 import questionary
 from rich import print
@@ -97,7 +97,7 @@ def clean_venv() -> None:
             ).ask()
             if Path(f"{path}/.venv").is_dir():
                 curr_path = os.getcwd()
-                clean_venv_cmd = f"rm -rf {curr_path}/{path}/.venv" 
+                clean_venv_cmd = f"rm -rf {curr_path}/{path}/.venv"
 
                 execute_command(
                     clean_venv_cmd,

--- a/src/ssb_project_cli/ssb_project/clean/clean.py
+++ b/src/ssb_project_cli/ssb_project/clean/clean.py
@@ -1,6 +1,7 @@
 """Clean command module."""
 import subprocess  # noqa: S404
 from pathlib import Path
+import os
 
 import questionary
 from rich import print
@@ -78,7 +79,7 @@ def clean_venv() -> None:
     ).ask()
     if confirm:
         if Path(".venv").is_dir():
-            clean_venv_cmd = "rm -rf .venv".split(" ")
+            clean_venv_cmd = "rm -rf .venv"
 
             execute_command(
                 clean_venv_cmd,
@@ -95,7 +96,8 @@ def clean_venv() -> None:
                 "Please provide the path to the ssb project you wish to delete the virtual environment for:"
             ).ask()
             if Path(f"{path}/.venv").is_dir():
-                clean_venv_cmd = f"rm -rf {path}/.venv".split(" ")
+                curr_path = os.getcwd()
+                clean_venv_cmd = f"rm -rf {curr_path}/{path}/.venv" 
 
                 execute_command(
                     clean_venv_cmd,

--- a/tests/clean_test/test_clean.py
+++ b/tests/clean_test/test_clean.py
@@ -38,7 +38,12 @@ def test_clean_venv(mock_confirm: Mock, mock_path: Mock, mock_execute: Mock) -> 
 
     clean_venv()
 
-    assert mock_execute.call_count == 1
+    mock_confirm.confirm().ask.return_value = True
+    mock_path.is_dir.return_value = False
+
+    clean_venv()
+
+    assert mock_execute.call_count == 2
 
 
 @patch(f"{CLEAN}.subprocess.run")


### PR DESCRIPTION
Cause of bug: 
-execute_command method supports commands in string and list formats. 
- bug caused by passing in command in list format