### PR TITLE
Clean was not cleaning kernels

### DIFF
--- a/src/ssb_project_cli/ssb_project/clean/clean.py
+++ b/src/ssb_project_cli/ssb_project/clean/clean.py
@@ -65,6 +65,7 @@ def get_kernels_dict() -> dict[str, str]:
     kernel_dict = {}
     for kernel in kernels_str.split("\n")[1:]:
         line = " ".join(kernel.strip().split())
+        line = line.replace("%s ","").strip()
         if len(line.split(" ")) == 2:
             k, v = line.split(" ")
             kernel_dict[k] = v

--- a/src/ssb_project_cli/ssb_project/clean/clean.py
+++ b/src/ssb_project_cli/ssb_project/clean/clean.py
@@ -65,7 +65,7 @@ def get_kernels_dict() -> dict[str, str]:
     kernel_dict = {}
     for kernel in kernels_str.split("\n")[1:]:
         line = " ".join(kernel.strip().split())
-        line = line.replace("%s ","").strip()
+        line = line.replace("%s ", "").strip()
         if len(line.split(" ")) == 2:
             k, v = line.split(" ")
             kernel_dict[k] = v


### PR DESCRIPTION
Seems like kernelspec was adding some new "%s" signs... (may be a temporary bug?)
Removing %s-s from kernelspec list, and stripping before making dictionary fixes the issue.

Reported by @aosthus 