### PR TITLE
Create log subfolders

### DIFF
--- a/src/ssb_project_cli/ssb_project/util.py
+++ b/src/ssb_project_cli/ssb_project/util.py
@@ -19,6 +19,9 @@ def set_debug_logging(home_path: Path = HOME_PATH) -> None:
         home_path: path prefix to use for error logging, defaults to HOME_PATH.
     """
     error_logs_path = f"{home_path}/ssb-project-cli/.error_logs/ssb-project-debug.log"
+    log_dir = os.path.dirname(error_logs_path)
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
     logging.basicConfig(filename=error_logs_path, level=logging.DEBUG)
 
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,10 +1,13 @@
 """Tests utils functions."""
+import tempfile
+from pathlib import Path
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
 
 from ssb_project_cli.ssb_project.util import execute_command
+from ssb_project_cli.ssb_project.util import set_debug_logging
 
 
 UTILS = "ssb_project_cli.ssb_project.util"
@@ -42,3 +45,10 @@ def test_execute_command_success(mock_run: Mock, mock_print: Mock) -> None:
 
     assert mock_run.call_count == 1
     mock_print.assert_called_with("Success")
+
+
+def test_set_debug_logging_folders_created() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        error_logs_path = Path(f"{tempdir}/ssb-project-cli/.error_logs/")
+        set_debug_logging(home_path=Path(tempdir))
+        assert error_logs_path.is_dir()


### PR DESCRIPTION
If the user has not encountered an error with ssb-project before or had deleted the ssb-project folder logging would raise an error when setting the output log-file.

- Added check for if the folder exists, if not then ssb-project will create it.
- Added a test case for the issue.