### PR TITLE
Fix deprecated 'default' option in poetry source command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-project-cli"
-version = "1.1.0"
+version = "1.1.1"
 description = "SSB Project CLI"
 authors = ["Statistics Norway <stat-dev@ssb.no>"]
 license = "MIT"

--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -95,7 +95,7 @@ def poetry_source_add(
     """
     print("Adding package installation source for poetry...")
     execute_command(
-        f"poetry source add --default {source_name} {source_url}".split(" "),
+        f"poetry source add --priority=primary {source_name} {source_url}".split(" "),
         "poetry-source-add",
         "Poetry source successfully added!",
         "Failed to add poetry source.",


### PR DESCRIPTION
Updated the 'poetry source add' command to use the '--priority=primary' option instead of the deprecated '--default' option. This change resolves the build issue related to the deprecated key in the pyproject.toml configuration file for the 'nexus' source onprem.

When testing the changes oprem, the uhv-oljegass project builds successfully:
<img width="759" alt="Screenshot 2023-05-26 at 15 40 39" src="https://github.com/statisticsnorway/ssb-project-cli/assets/8294494/0995f539-7868-48f7-98f1-4f80b5ef4a3b">
