### PR TITLE
Restoring Default Priority for Poetry Source Nexus and Resolving Deprecation Issue

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
 pip==22.3.1
 nox==2022.11.21
 nox-poetry==1.0.2
-poetry==1.2.2
+poetry==1.5.0
 virtualenv==20.17.0

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,6 @@
-pip==22.3.1
+pip==23.0.1
 nox==2022.11.21
 nox-poetry==1.0.2
 poetry==1.5.0
-virtualenv==20.17.0
+virtualenv==20.23.0
+urllib3>=1.26.0,<2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-project-cli"
-version = "1.1.1"
+version = "1.1.2"
 description = "SSB Project CLI"
 authors = ["Statistics Norway <stat-dev@ssb.no>"]
 license = "MIT"

--- a/src/ssb_project_cli/ssb_project/build/build.py
+++ b/src/ssb_project_cli/ssb_project/build/build.py
@@ -73,7 +73,7 @@ def build_project(
             ":twisted_rightwards_arrows:\tDetected onprem environment, using proxy for package installation"
         )
         if poetry_source_includes_source_name(project_directory):
-            poetry_source_remove(project_directory)
+            poetry_source_remove(project_directory, lock_update=False)
         poetry_source_add(PIP_INDEX_URL, project_directory)
     elif poetry_source_includes_source_name(project_directory):
         print(

--- a/src/ssb_project_cli/ssb_project/build/build.py
+++ b/src/ssb_project_cli/ssb_project/build/build.py
@@ -72,6 +72,8 @@ def build_project(
         print(
             ":twisted_rightwards_arrows:\tDetected onprem environment, using proxy for package installation"
         )
+        if poetry_source_includes_source_name(project_directory):
+            poetry_source_remove(project_directory)
         poetry_source_add(PIP_INDEX_URL, project_directory)
     elif poetry_source_includes_source_name(project_directory):
         print(

--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -58,11 +58,14 @@ def poetry_source_includes_source_name(
     return source_name in result.stdout.decode("utf-8")
 
 
-def poetry_source_remove(cwd: Path, source_name: str = NEXUS_SOURCE_NAME) -> None:
+def poetry_source_remove(
+    cwd: Path, lock_update: bool = True, source_name: str = NEXUS_SOURCE_NAME
+) -> None:
     """Remove a package installation source for this project.
 
     Args:
         cwd: Path of project to add source to
+        lock_update: Bool used to decide whether to run update_lock
         source_name: Name of source to be removed
     """
     print("Removing Poetry source...")
@@ -73,14 +76,8 @@ def poetry_source_remove(cwd: Path, source_name: str = NEXUS_SOURCE_NAME) -> Non
         "Failed to remove Poetry source.",
         cwd=cwd,
     )
-    print("Refreshing lock file...")
-    execute_command(
-        "poetry lock --no-update".split(" "),
-        "source-remove",
-        "Poetry successfully refreshed lock file!",
-        "Poetry failed to refresh lock file.",
-        cwd=cwd,
-    )
+    if lock_update:
+        update_lock(cwd)
 
 
 def poetry_source_add(
@@ -95,7 +92,7 @@ def poetry_source_add(
     """
     print("Adding package installation source for poetry...")
     execute_command(
-        f"poetry source add --priority=primary {source_name} {source_url}".split(" "),
+        f"poetry source add --priority=default {source_name} {source_url}".split(" "),
         "poetry-source-add",
         "Poetry source successfully added!",
         "Failed to add poetry source.",
@@ -104,14 +101,23 @@ def poetry_source_add(
 
     # If the lock is created off-prem, we need to refresh the lock.
     if should_update_lock_file(source_url, cwd):
-        print("Refreshing lock file...")
-        execute_command(
-            "poetry lock --no-update".split(" "),
-            "source-remove",
-            "Poetry successfully refreshed lock file!",
-            "Poetry failed to refresh lock file.",
-            cwd=cwd,
-        )
+        update_lock(cwd)
+
+
+def update_lock(cwd: Path) -> None:
+    """Runs poetry lock --no-update command in CWD.
+
+    Args:
+        cwd: Path of project to add source to.
+    """
+    print("Refreshing lock file...")
+    execute_command(
+        "poetry lock --no-update".split(" "),
+        "update_lock",
+        "Poetry successfully refreshed lock file!",
+        "Poetry failed to refresh lock file.",
+        cwd=cwd,
+    )
 
 
 def should_update_lock_file(source_url: str, cwd: Path) -> bool:

--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -127,7 +127,7 @@ def should_update_lock_file(source_url: str, cwd: Path) -> bool:
         source_url: URL of 'simple' package API of package server
         cwd: Path of project to add source to
     Returns:
-        True if nexus source is not set in lock file, else False.
+        True if source url is not set in lock file, else False.
     """
     lock_file_path = cwd / Path("poetry.lock")
     if os.path.isfile(lock_file_path):

--- a/tests/unit/build_test/test_build.py
+++ b/tests/unit/build_test/test_build.py
@@ -27,8 +27,8 @@ BUILD = "ssb_project_cli.ssb_project.build.build"
     "running_onprem_return,poetry_source_includes_source_name_return,calls_to_poetry_source_includes_source_name,calls_to_poetry_source_add,calls_to_poetry_source_remove",
     [
         (False, False, 1, 0, 0),
-        (True, False, 0, 1, 0),
-        (True, True, 0, 1, 0),
+        (True, False, 1, 1, 0),
+        (True, True, 1, 1, 1),
         (False, True, 1, 0, 1),
     ],
 )

--- a/tests/unit/build_test/test_files/test_nexus_source_add_pyproject.toml
+++ b/tests/unit/build_test/test_files/test_nexus_source_add_pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "test-test"
+version = "0.0.0"
+description = "Test description"
+authors = ["TestName <test-email@test.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.11"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/unit/build_test/test_files/test_nexus_source_update_pyproject.toml
+++ b/tests/unit/build_test/test_files/test_nexus_source_update_pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "test-test"
+version = "0.0.0"
+description = "Test description"
+authors = ["TestName <test-email@test.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.11"
+
+[[tool.poetry.source]]
+name = "nexus"
+url = "http://pl-nexuspro-p.ssb.no:8081/repository/pypi-proxy/simple"
+default = true
+secondary = false
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/unit/build_test/test_poetry.py
+++ b/tests/unit/build_test/test_poetry.py
@@ -1,14 +1,20 @@
 """Tests for the poetry module."""
+import shutil
+import tempfile
 from pathlib import Path
 from unittest.mock import Mock
+from unittest.mock import call
 from unittest.mock import mock_open
 from unittest.mock import patch
 
 import pytest
 
 from ssb_project_cli.ssb_project.build.environment import NEXUS_SOURCE_NAME
+from ssb_project_cli.ssb_project.build.poetry import poetry_source_add
 from ssb_project_cli.ssb_project.build.poetry import poetry_source_includes_source_name
+from ssb_project_cli.ssb_project.build.poetry import poetry_source_remove
 from ssb_project_cli.ssb_project.build.poetry import should_update_lock_file
+from ssb_project_cli.ssb_project.build.poetry import update_lock
 from ssb_project_cli.ssb_project.clean.clean import get_kernels_dict
 
 
@@ -53,21 +59,21 @@ def test_get_kernels_dict(mock_run: Mock) -> None:
         (
             True,
             """
-            [package.source]
-            type = "legacy"
-            url = "http://pl-nexuspro-p.ssb.no:8081/repository/pypi-proxy/simple"
-            reference = "nexus"
-            [[package]]""",
+                    [package.source]
+                    type = "legacy"
+                    url = "http://pl-nexuspro-p.ssb.no:8081/repository/pypi-proxy/simple"
+                    reference = "nexus"
+                    [[package]]""",
             False,
         ),
         (
             True,
             """
-            [package.source]
-            type = "legacy"
-            url = "No url"
-            reference = "nexus"
-            [[package]]""",
+                    [package.source]
+                    type = "legacy"
+                    url = "No url"
+                    reference = "nexus"
+                    [[package]]""",
             True,
         ),
         (
@@ -85,3 +91,59 @@ def test_should_update_lock_file(isfile: bool, data: str, expected: bool) -> Non
                 "http://pl-nexuspro-p.ssb.no:8081/repository/pypi-proxy/simple",
                 Path(),
             )
+
+
+@patch(f"{POETRY}.execute_command")
+def test_update_lock_execute_command_call_args(mock_run: Mock) -> None:
+    update_lock(Path("fake_path"))
+    assert (
+        call(
+            ["poetry", "lock", "--no-update"],
+            "update_lock",
+            "Poetry successfully refreshed lock file!",
+            "Poetry failed to refresh lock file.",
+            cwd=Path("fake_path"),
+        )
+        in mock_run.call_args_list
+    )
+
+
+def test_poetry_source_remove() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_file_path = Path(temp_dir)
+
+        shutil.copyfile(
+            "tests/unit/build_test/test_files/test_nexus_source_update_pyproject.toml",
+            project_file_path / Path("pyproject.toml"),
+        )
+        # Confirm that a source exists
+        assert poetry_source_includes_source_name(project_file_path) is True
+        # Remove the source
+        poetry_source_remove(cwd=project_file_path, lock_update=False)
+        # Confirm that the source is removed
+        assert poetry_source_includes_source_name(project_file_path) is False
+
+
+def test_poetry_source_add() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_file_path = Path(temp_dir)
+        fake_pypi_url = "https://fake-pypi.org/simple"
+
+        shutil.copyfile(
+            "tests/unit/build_test/test_files/test_nexus_source_add_pyproject.toml",
+            project_file_path / Path("pyproject.toml"),
+        )
+
+        # Confirm that the no source is set
+        assert poetry_source_includes_source_name(project_file_path) is False
+        # Add source to pyproject.toml
+        poetry_source_add(fake_pypi_url, project_file_path, "fake_pypi")
+        # Confirm that the source is set in pyproject.toml
+        assert (
+            poetry_source_includes_source_name(project_file_path, "fake_pypi") is True
+        )
+
+        # Confirm that fake_pypi_url is set in the lockfile
+        # should_update_lock_file returns False if the source_url
+        # is set in the project lockfile
+        assert should_update_lock_file(fake_pypi_url, project_file_path) is False


### PR DESCRIPTION
The priority for the poetry source `nexus` is set back to `default`, when running on-prem. This fixes the error where poetry would try to install packages form PyPi onprem.

If the source is already set we remove it, this is done to avoid the error that occurs when source is set with the deprecated `--default` option like we did before: `poetry source add --default nexus "echo $PIP_INDEX_URL"`.

If the source is not removed beforehand this results in the error:
```
~/uhv-oljegass (main)$ poetry source add --priority=default nexus `echo $PIP_INDEX_URL`
Warning: Found deprecated key 'default' or 'secondary' in pyproject.toml configuration for source nexus. Please provide the key 'priority' instead. Accepted values are: 'default', 'primary', 'secondary', 'supplemental', 'explicit'.
Source with name nexus is already set to default. Only one default source can be configured at a time.
```

Tested by building uhv-oljegass onprem:
<img width="723" alt="Screenshot 2023-05-30 at 11 42 49" src="https://github.com/statisticsnorway/ssb-project-cli/assets/8294494/a264359a-0ee6-4dc1-88aa-843ccd43ec8d">

Tested by create new project onprem:
<img width="843" alt="Screenshot 2023-05-30 at 11 44 21" src="https://github.com/statisticsnorway/ssb-project-cli/assets/8294494/298bfb0f-9491-4c68-a1ed-507d6b5a375f">