### PR TITLE
Correct trigger for documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,11 +1,10 @@
 name: Documentation
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
-      - "release"
+      - main
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
The documentation page is very outdated because the deploy action is never triggered.

https://statisticsnorway.github.io/ssb-project-cli/