### PR TITLE
:bug: Robust method for discovering project name

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -165,7 +165,7 @@ def mypy(session: Session) -> None:
 def unit_tests(session: Session) -> None:
     """Run the unit tests."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments")
+    session.install("coverage[toml]", "pytest", "pygments", "tomli-w")
     try:
         session.run(
             "coverage",
@@ -185,7 +185,7 @@ def unit_tests(session: Session) -> None:
 def integration_tests(session: Session) -> None:
     """Run the unit tests."""
     session.install(".")
-    session.install("pytest")
+    session.install("pytest", "tomli-w")
     session.run(
         "pytest",
         INTEGRATION_TESTS_PATH,
@@ -211,7 +211,7 @@ def coverage(session: Session) -> None:
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
-    session.install("pytest", "typeguard", "pygments")
+    session.install("pytest", "typeguard", "pygments", "tomli-w")
     session.run(
         "pytest", f"--typeguard-packages={package}", UNIT_TESTS_PATH, *session.posargs
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -3989,4 +3989,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "345c58c3c890d79238d711de34f40753da581ef113f9eb809308c6d1ffde3f28"
+content-hash = "74de26b6c31a725eb3917e973dbca7159a3b54cf0028544d3499efcdefedba86"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3523,6 +3523,17 @@ files = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.0.0"
+description = "A lil' TOML writer"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463"},
+    {file = "tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9"},
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.12.1"
 description = "Style preserving TOML library"
@@ -3978,4 +3989,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "395f864f0b3a4a73a1ee73edb7d743d28539b042c2ea94308a1627719af28f89"
+content-hash = "345c58c3c890d79238d711de34f40753da581ef113f9eb809308c6d1ffde3f28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ build = ">=0.8.0"
 jinja2 = ">=3.1.2"
 nox = ">=2022.11.21"
 nox-poetry = ">=1.0.2"
+tomli-w = "^1.0.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ kvakk-git-tools = ">=2.2.1"
 poetry = ">=1.5.0"
 jupyter-client = ">=8.3.1"
 ipykernel = ">=6.25.2"
+tomli = ">=2.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pygments = ">=2.10.0"
@@ -58,7 +59,7 @@ build = ">=0.8.0"
 jinja2 = ">=3.1.2"
 nox = ">=2022.11.21"
 nox-poetry = ">=1.0.2"
-tomli-w = "^1.0.0"
+tomli-w = ">=1.0.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -101,8 +101,8 @@ def create(  # noqa: C901
 
 @app.command()
 def build(
-    path: Path = typer.Argument(  # noqa: B008
-        "",
+    path: t.Optional[Path] = typer.Argument(  # noqa: B008
+        None,
         help="Project path",
     ),
     verify_config: bool = typer.Option(  # noqa: B008

--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -153,3 +153,4 @@ def install_ipykernel(project_name: str) -> None:
     ) as progress:
         progress.add_task(description="Installing Jupyter kernel...", total=None)
         install_kernel(project_name)
+    print(f":white_check_mark:\tInstalled Jupyter Kernel ({project_name})")

--- a/tests/unit/build_test/test_build.py
+++ b/tests/unit/build_test/test_build.py
@@ -25,7 +25,6 @@ BUILD = "ssb_project_cli.ssb_project.build.build"
 @patch(f"{BUILD}.poetry_source_includes_source_name")
 @patch(f"{BUILD}.poetry_source_add")
 @patch(f"{BUILD}.poetry_source_remove")
-@patch("pathlib.Path.is_file")
 @patch("typer.confirm")
 @patch("kvakk_git_tools.validate_git_config")
 @patch("ssb_project_cli.ssb_project.build.environment.verify_local_config")
@@ -42,7 +41,6 @@ def test_build(
     mock_verify_local_config: Mock,
     mock_kvakk: Mock,
     mock_confirm: Mock,
-    mock_file_found: Mock,
     mock_poetry_source_remove: Mock,
     mock_poetry_source_add: Mock,
     mock_poetry_source_includes_source_name: Mock,
@@ -61,7 +59,6 @@ def test_build(
     mock_kvakk.return_value = True
     mock_verify_local_config.return_value = True
     mock_running_onprem.return_value = running_onprem_return
-    mock_file_found.return_value = True
     mock_confirm.return_value = False
     mock_poetry_source_includes_source_name.return_value = (
         poetry_source_includes_source_name_return
@@ -72,7 +69,6 @@ def test_build(
     assert mock_kvakk.called
     assert mock_verify_local_config
     assert mock_confirm.call_count == 1
-    assert mock_file_found.call_count == 1
     assert mock_poetry_install.call_count == 1
     assert mock_install_ipykernel.call_count == 1
     assert mock_ipykernel_attach_bashrc.call_count == 1

--- a/tests/unit/build_test/test_build.py
+++ b/tests/unit/build_test/test_build.py
@@ -28,6 +28,7 @@ BUILD = "ssb_project_cli.ssb_project.build.build"
 @patch("typer.confirm")
 @patch("kvakk_git_tools.validate_git_config")
 @patch("ssb_project_cli.ssb_project.build.environment.verify_local_config")
+@patch(f"{BUILD}.get_project_name_and_root_path")
 @pytest.mark.parametrize(
     "running_onprem_return,poetry_source_includes_source_name_return,calls_to_poetry_source_includes_source_name,calls_to_poetry_source_add,calls_to_poetry_source_remove",
     [
@@ -38,6 +39,7 @@ BUILD = "ssb_project_cli.ssb_project.build.build"
     ],
 )
 def test_build(
+    mock_get_project_name_and_root_path: Mock,
     mock_verify_local_config: Mock,
     mock_kvakk: Mock,
     mock_confirm: Mock,
@@ -60,6 +62,7 @@ def test_build(
     mock_verify_local_config.return_value = True
     mock_running_onprem.return_value = running_onprem_return
     mock_confirm.return_value = False
+    mock_get_project_name_and_root_path.return_value = ("project_name", tmp_path)
     mock_poetry_source_includes_source_name.return_value = (
         poetry_source_includes_source_name_return
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,12 +1,15 @@
 """Tests utils functions."""
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+import tomli_w
 
 from ssb_project_cli.ssb_project.util import execute_command
+from ssb_project_cli.ssb_project.util import get_project_name_and_root_path
 from ssb_project_cli.ssb_project.util import set_debug_logging
 
 
@@ -52,3 +55,50 @@ def test_set_debug_logging_folders_created() -> None:
         error_logs_path = Path(f"{tempdir}/ssb-project-cli/.error_logs/")
         set_debug_logging(home_path=Path(tempdir))
         assert error_logs_path.is_dir()
+
+
+def test_get_project_name_cruft_json(tmp_path: Path) -> None:
+    name = "my-project-name"
+    content = {"context": {"cookiecutter": {"project_name": name}}}
+    with (tmp_path / ".cruft.json").open("w") as f:
+        f.write(json.dumps(content))
+    assert get_project_name_and_root_path(tmp_path) == (name, tmp_path)
+
+
+def test_get_project_name_pyproject_toml(tmp_path: Path) -> None:
+    name = "my-project-name"
+    content = {"tool": {"poetry": {"name": name}}}
+    with (tmp_path / "pyproject.toml").open("w") as f:
+        f.write(tomli_w.dumps(content))
+    assert get_project_name_and_root_path(tmp_path) == (name, tmp_path)
+
+
+def test_get_project_name_git_directory(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    assert get_project_name_and_root_path(tmp_path) == (tmp_path.name, tmp_path)
+
+
+def test_get_project_name_nested_directory(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    origin = (
+        tmp_path
+        / "deeply"
+        / "nested"
+        / "directory"
+        / "structure"
+        / "that"
+        / "goes"
+        / "some"
+        / "levels"
+        / "down"
+    )
+    origin.mkdir(parents=True)
+    assert get_project_name_and_root_path(origin) == (tmp_path.name, tmp_path)
+
+
+def test_get_project_name_non_existing_path(tmp_path: Path) -> None:
+    assert get_project_name_and_root_path(tmp_path / "fake") == (None, None)
+
+
+def test_get_project_name_non_project_dir(tmp_path: Path) -> None:
+    assert get_project_name_and_root_path(tmp_path) == (None, None)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
-import tomli_w
+import tomli_w  # type: ignore[import]
 
 from ssb_project_cli.ssb_project.util import execute_command
 from ssb_project_cli.ssb_project.util import get_project_name_and_root_path


### PR DESCRIPTION
- Three methods with fallback for discovering project root and name.
- Used for create and build.
- Fix for #253 
