### PR TITLE
Remove unused arg 'user_bypass_pull_request_allowances=[]'

### DIFF
--- a/src/ssb_project_cli/ssb_project/create/github.py
+++ b/src/ssb_project_cli/ssb_project/create/github.py
@@ -207,7 +207,6 @@ def set_branch_protection_rules(
         required_approving_review_count=1,
         dismiss_stale_reviews=True,
         enforce_admins=True,
-        user_bypass_pull_request_allowances=[],  # Supply this as workaround for https://github.com/PyGithub/PyGithub/issues/2578
     )
 
 

--- a/src/ssb_project_cli/ssb_project/create/github.py
+++ b/src/ssb_project_cli/ssb_project/create/github.py
@@ -207,7 +207,6 @@ def set_branch_protection_rules(
         required_approving_review_count=1,
         dismiss_stale_reviews=True,
         enforce_admins=True,
-        users_bypass_pull_request_allowances=[],  # Supply this as workaround for https://github.com/PyGithub/PyGithub/issues/2578
     )
 
 

--- a/src/ssb_project_cli/ssb_project/create/github.py
+++ b/src/ssb_project_cli/ssb_project/create/github.py
@@ -207,6 +207,7 @@ def set_branch_protection_rules(
         required_approving_review_count=1,
         dismiss_stale_reviews=True,
         enforce_admins=True,
+        users_bypass_pull_request_allowances=[],  # Supply this as workaround for https://github.com/PyGithub/PyGithub/issues/2578
     )
 
 


### PR DESCRIPTION
Issue in PyGithub has been patched:
https://github.com/PyGithub/PyGithub/issues/2578
And backported:
https://github.com/PyGithub/PyGithub/issues/2719

..so we can remove the workaround