### PR TITLE
Fix test of 'create_github'

### DIFF
--- a/tests/unit/create_test/test_github.py
+++ b/tests/unit/create_test/test_github.py
@@ -20,7 +20,6 @@ from ssb_project_cli.ssb_project.create.github import get_org_members
 from ssb_project_cli.ssb_project.create.github import is_github_repo
 from ssb_project_cli.ssb_project.create.github import set_branch_protection_rules
 
-
 GITHUB = "ssb_project_cli.ssb_project.create.github"
 
 
@@ -32,12 +31,12 @@ def test_create_github(mock_github: Mock) -> None:
 
 
 @patch(f"{GITHUB}.create_error_log")
-@patch(f"{GITHUB}.Github.get_repo")
+@patch(f"{GITHUB}.Github.get_organization")
 def test_create_github_bad_credentials(
-    mock_github_create_repo: Mock, mock_log: Mock
+    mock_github_get_organization: Mock, mock_log: Mock
 ) -> None:
     """Checks if create_github works."""
-    mock_github_create_repo.return_value = BadCredentialsException(
+    mock_github_get_organization.return_value = BadCredentialsException(
         Mock(), Mock(), Mock()
     )
 


### PR DESCRIPTION
After the implementation of 'create_github' was changed, this caused a mock to be ineffective and resulted in an actual API call. This fails inside the Dockerized tests ran on GitHub due to 
lack of access to the open internet
