### PR TITLE
Fix template bug

### DIFF
--- a/src/ssb_project_cli/ssb_project/create/local_repo.py
+++ b/src/ssb_project_cli/ssb_project/create/local_repo.py
@@ -48,7 +48,7 @@ def create_project_from_template(
         Path: Path of project.
     """
     if override_dir is None:
-        project_dir = working_directory.joinpath(project_name)
+        project_dir = working_directory
     else:
         project_dir = override_dir
 
@@ -167,6 +167,7 @@ def reset_project_git_configuration(
         project_directory: Directory of the project.
     """
     files = [".gitattributes", ".gitignore"]
+    print("Heihei")
     try:
         with tempfile.TemporaryDirectory() as tempdir:
             create_project_from_template(

--- a/src/ssb_project_cli/ssb_project/create/local_repo.py
+++ b/src/ssb_project_cli/ssb_project/create/local_repo.py
@@ -67,6 +67,7 @@ def create_project_from_template(
     cruft.create(
         template_git_url=template_repo_url,
         checkout=checkout,
+        output_dir=project_dir,
         no_input=(template_repo_url == STAT_TEMPLATE_REPO_URL),
         extra_context=template_info,
     )

--- a/src/ssb_project_cli/ssb_project/create/local_repo.py
+++ b/src/ssb_project_cli/ssb_project/create/local_repo.py
@@ -167,7 +167,6 @@ def reset_project_git_configuration(
         project_directory: Directory of the project.
     """
     files = [".gitattributes", ".gitignore"]
-    print("Heihei")
     try:
         with tempfile.TemporaryDirectory() as tempdir:
             create_project_from_template(


### PR DESCRIPTION
When resetting the git configuration in an existing project, we created a project in a temporary directory, and copied over the .gitattributes and .gitignore files from that project into our current directory. 

However, there was a missing argument when creating the project in the tempdir, which caused the project to be created in the *current* directory. This then caused the copying operation to fail. 
