### PR TITLE
Support templates without poetry.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,14 @@ jobs:
 
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
-        uses: release-drafter/release-drafter@v5.21.1
+        uses: release-drafter/release-drafter@v5.25.0
         with:
           publish: ${{ steps.check-version.outputs.tag != '' }}
           tag: ${{ steps.check-version.outputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,14 +99,14 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'unit_tests'
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@v4"
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.os }}-${{ matrix.python }}
           path: ".coverage.*"
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build
@@ -140,9 +140,10 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: Combine coverage data and display human readable report
         run: |
@@ -153,4 +154,4 @@ jobs:
           nox --session=coverage -- xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,13 +60,6 @@ repos:
         language: system
         types: [text]
         stages: [commit, push, manual]
-      - id: mypy
-        name: mypy
-        entry: mypy src tests
-        require_serial: true
-        language: system
-        types: [python]
-        pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.0
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1314,13 +1314,13 @@ trio = ["async_generator", "trio"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
-    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]

--- a/src/ssb_project_cli/ssb_project/build/build.py
+++ b/src/ssb_project_cli/ssb_project/build/build.py
@@ -9,14 +9,10 @@ from typing import List
 
 import kvakk_git_tools.validate_ssb_gitconfig  # type: ignore
 
-from .environment import JUPYTER_IMAGE_SPEC, verify_local_config
-from .environment import PIP_INDEX_URL
-from .environment import running_onprem
+from .environment import verify_local_config
 from .poetry import install_ipykernel
 from .poetry import poetry_install
-from .poetry import poetry_source_add
-from .poetry import poetry_source_includes_source_name
-from .poetry import poetry_source_remove
+from .poetry import check_and_fix_onprem_source
 from rich import print
 
 from .prompt import confirm_fix_ssb_git_config
@@ -63,18 +59,7 @@ def build_project(
             template_repo_url, checkout, project_name, project_root
         )
 
-    if running_onprem(JUPYTER_IMAGE_SPEC):
-        print(
-            ":twisted_rightwards_arrows:\tDetected onprem environment, using proxy for package installation"
-        )
-        if poetry_source_includes_source_name(project_root):
-            poetry_source_remove(project_root, lock_update=False)
-        poetry_source_add(PIP_INDEX_URL, project_root)
-    elif poetry_source_includes_source_name(project_root):
-        print(
-            ":twisted_rightwards_arrows:\tDetected non-onprem environment, removing proxy for package installation"
-        )
-        poetry_source_remove(project_root)
+    check_and_fix_onprem_source(project_root)
 
     poetry_install(project_root)
     if not no_kernel:

--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -35,6 +35,33 @@ def poetry_install(project_directory: Path) -> None:
         )
 
 
+def poetry_update_lockfile_dependencies(project_directory: Path) -> None:
+    """Call poetry update --lock in project_directory.
+
+    Update the lock file dependencies without installing packages.
+
+    Args:
+        project_directory: Path of project
+    """
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+    ) as progress:
+        progress.add_task(
+            description="Updating lock file dependencies... This may take some time.",
+            total=None,
+        )
+
+        execute_command(
+            "poetry update --lock".split(" "),
+            "poetry-update-lock-deps",
+            ":white_check_mark:\tUpdated lock file dependencies",
+            "Error: Something went wrong when updating lock file dependencies with Poetry.",
+            project_directory,
+        )
+
+
 def poetry_source_includes_source_name(
     cwd: Path, source_name: str = NEXUS_SOURCE_NAME
 ) -> bool:

--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -8,6 +8,9 @@ from rich import print
 
 from .environment import NEXUS_SOURCE_NAME
 from ssb_project_cli.ssb_project.util import execute_command
+from .environment import JUPYTER_IMAGE_SPEC
+from .environment import PIP_INDEX_URL
+from .environment import running_onprem
 
 
 def poetry_install(project_directory: Path) -> None:
@@ -191,3 +194,23 @@ def install_ipykernel(project_directory: Path, project_name: str) -> None:
             "Something went wrong while installing ipykernel.",
             project_directory,
         )
+
+
+def check_and_fix_onprem_source(project_root: Path) -> None:
+    """Check if running onprem and fix source in pyproject.toml if so.
+
+    Args:
+        project_root: Path to the root of the project
+    """
+    if running_onprem(JUPYTER_IMAGE_SPEC):
+        print(
+            ":twisted_rightwards_arrows:\tDetected onprem environment, using proxy for package installation"
+        )
+        if poetry_source_includes_source_name(project_root):
+            poetry_source_remove(project_root, lock_update=False)
+        poetry_source_add(PIP_INDEX_URL, project_root)
+    elif poetry_source_includes_source_name(project_root):
+        print(
+            ":twisted_rightwards_arrows:\tDetected non-onprem environment, removing proxy for package installation"
+        )
+        poetry_source_remove(project_root)

--- a/src/ssb_project_cli/ssb_project/create/local_repo.py
+++ b/src/ssb_project_cli/ssb_project/create/local_repo.py
@@ -10,6 +10,7 @@ import cruft
 from git import Repo
 from rich import print
 
+from ssb_project_cli.ssb_project.build.poetry import poetry_update_lockfile_dependencies
 from ssb_project_cli.ssb_project.create import temp_git_repo
 from ssb_project_cli.ssb_project.create.github import (
     get_environment_specific_github_object,
@@ -71,6 +72,7 @@ def create_project_from_template(
         no_input=(template_repo_url == STAT_TEMPLATE_REPO_URL),
         extra_context=template_info,
     )
+    poetry_update_lockfile_dependencies(project_dir)
 
     return project_dir
 

--- a/src/ssb_project_cli/ssb_project/create/local_repo.py
+++ b/src/ssb_project_cli/ssb_project/create/local_repo.py
@@ -10,6 +10,7 @@ import cruft
 from git import Repo
 from rich import print
 
+from ssb_project_cli.ssb_project.build.poetry import check_and_fix_onprem_source
 from ssb_project_cli.ssb_project.build.poetry import poetry_update_lockfile_dependencies
 from ssb_project_cli.ssb_project.create import temp_git_repo
 from ssb_project_cli.ssb_project.create.github import (
@@ -72,7 +73,9 @@ def create_project_from_template(
         no_input=(template_repo_url == STAT_TEMPLATE_REPO_URL),
         extra_context=template_info,
     )
-    poetry_update_lockfile_dependencies(project_dir)
+    project_root = project_dir / project_name
+    check_and_fix_onprem_source(project_root)
+    poetry_update_lockfile_dependencies(project_root)
 
     return project_dir
 

--- a/tests/unit/build_test/test_poetry.py
+++ b/tests/unit/build_test/test_poetry.py
@@ -10,15 +10,33 @@ from unittest.mock import patch
 import pytest
 
 from ssb_project_cli.ssb_project.build.environment import NEXUS_SOURCE_NAME
+from ssb_project_cli.ssb_project.build.poetry import poetry_install
 from ssb_project_cli.ssb_project.build.poetry import poetry_source_add
 from ssb_project_cli.ssb_project.build.poetry import poetry_source_includes_source_name
 from ssb_project_cli.ssb_project.build.poetry import poetry_source_remove
+from ssb_project_cli.ssb_project.build.poetry import poetry_update_lockfile_dependencies
 from ssb_project_cli.ssb_project.build.poetry import should_update_lock_file
 from ssb_project_cli.ssb_project.build.poetry import update_lock
 
 
 POETRY = "ssb_project_cli.ssb_project.build.poetry"
 CLEAN = "ssb_project_cli.ssb_project.clean.clean"
+
+
+@patch(f"{POETRY}.execute_command")
+def test_poetry_install(mock_run: Mock) -> None:
+    project_dir = Path(__file__).parent  # Just some dummy dir, not used
+    poetry_install(project_dir)
+    assert mock_run.call_count == 1
+    assert mock_run.call_args[0][0] == ["poetry", "install"]
+
+
+@patch(f"{POETRY}.execute_command")
+def test_poetry_update_lockfile_dependencies(mock_run: Mock) -> None:
+    project_dir = Path(__file__).parent  # Just some dummy dir, not used
+    poetry_update_lockfile_dependencies(project_dir)
+    assert mock_run.call_count == 1
+    assert mock_run.call_args[0][0] == ["poetry", "update", "--lock"]
 
 
 @patch(f"{POETRY}.execute_command")

--- a/tests/unit/build_test/test_poetry.py
+++ b/tests/unit/build_test/test_poetry.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from ssb_project_cli.ssb_project.build.environment import NEXUS_SOURCE_NAME
+from ssb_project_cli.ssb_project.build.poetry import check_and_fix_onprem_source
 from ssb_project_cli.ssb_project.build.poetry import poetry_install
 from ssb_project_cli.ssb_project.build.poetry import poetry_source_add
 from ssb_project_cli.ssb_project.build.poetry import poetry_source_includes_source_name
@@ -149,3 +150,44 @@ def test_poetry_source_add() -> None:
         # should_update_lock_file returns False if the source_url
         # is set in the project lockfile
         assert should_update_lock_file(fake_pypi_url, project_file_path) is False
+
+
+@patch(f"{POETRY}.running_onprem")
+@patch(f"{POETRY}.poetry_source_includes_source_name")
+@patch(f"{POETRY}.poetry_source_add")
+@patch(f"{POETRY}.poetry_source_remove")
+@pytest.mark.parametrize(
+    "running_onprem_return,poetry_source_includes_source_name_return,calls_to_poetry_source_includes_source_name,calls_to_poetry_source_add,calls_to_poetry_source_remove",
+    [
+        (False, False, 1, 0, 0),
+        (True, False, 1, 1, 0),
+        (True, True, 1, 1, 1),
+        (False, True, 1, 0, 1),
+    ],
+)
+def test_check_and_fix_onprem_source(
+    mock_poetry_source_remove: Mock,
+    mock_poetry_source_add: Mock,
+    mock_poetry_source_includes_source_name: Mock,
+    mock_running_onprem: Mock,
+    running_onprem_return: bool,
+    poetry_source_includes_source_name_return: bool,
+    calls_to_poetry_source_includes_source_name: int,
+    calls_to_poetry_source_add: int,
+    calls_to_poetry_source_remove: int,
+    tmp_path: Path,
+) -> None:
+    mock_running_onprem.return_value = running_onprem_return
+    mock_poetry_source_includes_source_name.return_value = (
+        poetry_source_includes_source_name_return
+    )
+
+    check_and_fix_onprem_source(tmp_path)
+
+    assert mock_running_onprem.call_count == 1
+    assert (
+        mock_poetry_source_includes_source_name.call_count
+        == calls_to_poetry_source_includes_source_name
+    )
+    assert mock_poetry_source_add.call_count == calls_to_poetry_source_add
+    assert mock_poetry_source_remove.call_count == calls_to_poetry_source_remove

--- a/tests/unit/create_test/test_local_repo.py
+++ b/tests/unit/create_test/test_local_repo.py
@@ -106,20 +106,6 @@ def test_make_and_repo_and_push(
     assert test_repo.git.push.call_count == 1
 
 
-"""
-@patch(f"{LOCAL_REPO}.Repo.git.branch")
-@patch(f"{LOCAL_REPO}.Repo.index")
-@patch(f"{LOCAL_REPO}.Repo.git.add")
-@patch(f"{LOCAL_REPO}.Repo.init")
-def test_make_and_init_git_repo(mock_repo_init: Mock,mock_repo_add: Mock,mock_commit: Mock,mock_branch: Mock):
-    make_and_init_git_repo("/Users/anders/test/tt")
-    assert mock_repo_init.call_count == 1
-    assert mock_repo_add.call_count == 1
-    assert mock_commit.call_count == 1
-    assert mock_branch.call_count == 2
-"""
-
-
 def fake_run_gitconfig(cmd: list[str], stdout: int, encoding: str) -> Mock:
     """Emulates subprocess.run for git config --get."""
     vals = {
@@ -150,6 +136,7 @@ def test_extract_name_email(mock_run: Mock) -> None:
     assert extract_name_email() == ("Name2", "")
 
 
+@patch(f"{LOCAL_REPO}.check_and_fix_onprem_source")
 @patch(f"{LOCAL_REPO}.poetry_update_lockfile_dependencies")
 @patch(f"{LOCAL_REPO}.extract_name_email")
 @patch(f"{LOCAL_REPO}.request_name_email")
@@ -159,6 +146,7 @@ def test_create_project_from_template(
     mock_request: Mock,
     mock_extract: Mock,
     mock_poetry: Mock,
+    mock_check_and_fix_onprem_source: Mock,
     tmp_path: Path,
 ) -> None:
     """Checks if create_project_from_template works for a temporary path."""
@@ -176,8 +164,10 @@ def test_create_project_from_template(
     assert mock_extract.call_count == 1
     assert mock_request.call_count == 1
     assert mock_poetry.call_count == 1
+    assert mock_check_and_fix_onprem_source.call_count == 1
 
 
+@patch(f"{LOCAL_REPO}.check_and_fix_onprem_source")
 @patch(f"{LOCAL_REPO}.poetry_update_lockfile_dependencies")
 @patch(f"{LOCAL_REPO}.extract_name_email")
 @patch(f"{LOCAL_REPO}.request_name_email")
@@ -187,6 +177,7 @@ def test_create_project_from_template_license_year(
     mock_request: Mock,
     mock_extract: Mock,
     mock_poetry: Mock,
+    mock_check_and_fix_onprem_source: Mock,
     tmp_path: Path,
 ) -> None:
     """Verify that we supply the license year to Cruft"""
@@ -205,8 +196,11 @@ def test_create_project_from_template_license_year(
     context = mock_create.call_args.kwargs["extra_context"]
     assert context["license_year"] == license_year
     assert context["project_name"] == project_name
+    assert mock_poetry.call_count == 1
+    assert mock_check_and_fix_onprem_source.call_count == 1
 
 
+@patch(f"{LOCAL_REPO}.check_and_fix_onprem_source")
 @patch(f"{LOCAL_REPO}.poetry_update_lockfile_dependencies")
 @patch(f"{LOCAL_REPO}.extract_name_email")
 @patch(f"{LOCAL_REPO}.request_name_email")
@@ -216,6 +210,7 @@ def test_create_project_from_template_different_template_uri(
     mock_request: Mock,
     mock_extract: Mock,
     mock_poetry: Mock,
+    mock_check_and_fix_onprem_source: Mock,
     tmp_path: Path,
 ) -> None:
     """Check that different template uri works"""
@@ -234,3 +229,5 @@ def test_create_project_from_template_different_template_uri(
     context = mock_create.call_args.kwargs["extra_context"]
     assert context["license_year"] == license_year
     assert context["project_name"] == project_name
+    assert mock_poetry.call_count == 1
+    assert mock_check_and_fix_onprem_source.call_count == 1

--- a/tests/unit/create_test/test_local_repo.py
+++ b/tests/unit/create_test/test_local_repo.py
@@ -150,11 +150,16 @@ def test_extract_name_email(mock_run: Mock) -> None:
     assert extract_name_email() == ("Name2", "")
 
 
+@patch(f"{LOCAL_REPO}.poetry_update_lockfile_dependencies")
 @patch(f"{LOCAL_REPO}.extract_name_email")
 @patch(f"{LOCAL_REPO}.request_name_email")
 @patch(f"{LOCAL_REPO}.cruft.create")
 def test_create_project_from_template(
-    _mock_create: Mock, mock_request: Mock, mock_extract: Mock, tmp_path: Path
+    _mock_create: Mock,
+    mock_request: Mock,
+    mock_extract: Mock,
+    mock_poetry: Mock,
+    tmp_path: Path,
 ) -> None:
     """Checks if create_project_from_template works for a temporary path."""
     mock_extract.return_value = ("Name", "")
@@ -170,13 +175,19 @@ def test_create_project_from_template(
 
     assert mock_extract.call_count == 1
     assert mock_request.call_count == 1
+    assert mock_poetry.call_count == 1
 
 
+@patch(f"{LOCAL_REPO}.poetry_update_lockfile_dependencies")
 @patch(f"{LOCAL_REPO}.extract_name_email")
 @patch(f"{LOCAL_REPO}.request_name_email")
 @patch(f"{LOCAL_REPO}.cruft.create")
 def test_create_project_from_template_license_year(
-    mock_create: Mock, mock_request: Mock, mock_extract: Mock, tmp_path: Path
+    mock_create: Mock,
+    mock_request: Mock,
+    mock_extract: Mock,
+    mock_poetry: Mock,
+    tmp_path: Path,
 ) -> None:
     """Verify that we supply the license year to Cruft"""
     mock_extract.return_value = ("Name", "")
@@ -196,11 +207,16 @@ def test_create_project_from_template_license_year(
     assert context["project_name"] == project_name
 
 
+@patch(f"{LOCAL_REPO}.poetry_update_lockfile_dependencies")
 @patch(f"{LOCAL_REPO}.extract_name_email")
 @patch(f"{LOCAL_REPO}.request_name_email")
 @patch(f"{LOCAL_REPO}.cruft.create")
 def test_create_project_from_template_different_template_uri(
-    mock_create: Mock, mock_request: Mock, mock_extract: Mock, tmp_path: Path
+    mock_create: Mock,
+    mock_request: Mock,
+    mock_extract: Mock,
+    mock_poetry: Mock,
+    tmp_path: Path,
 ) -> None:
     """Check that different template uri works"""
     mock_extract.return_value = ("Name", "")


### PR DESCRIPTION
It is a maintenance issue to have templates containing a poetry.lock file. The templates need to be updated when vulnerabilities in poetry.lock are found, and when instances of the template are updated with `cruft update`, it almost always shows conflicts in `poetry.lock`. With this PR  `poetry update --lock` is run after create, to get a fresh and updated `poetry.lock` file and the templates does not need to have a `poetry.lock` file.

There are 3 commits. The first one adds and use the function `poetry_update_lockfile_dependencies`.

The second one makes it work onprem too. Extracted code to a `check_and_fix_onprem_source`-function, and had to move it to `poetry.py` to avoid circular dependencies.

The third one is mainly update of GitHub Actions versions, and some fixes to make it work (download-artifact v4 with new options). And removed mypy-checks from pre-commit since there is a separate mypy nox-session and mypy was run twice.