### PR TITLE
Update poetry.py

### DIFF
--- a/src/ssb_project_cli/ssb_project/build/poetry.py
+++ b/src/ssb_project_cli/ssb_project/build/poetry.py
@@ -122,7 +122,7 @@ def poetry_source_add(
     """
     print("Adding package installation source for poetry...")
     execute_command(
-        f"poetry source add --priority=default {source_name} {source_url}".split(" "),
+        f"poetry source add --priority=primary {source_name} {source_url}".split(" "),
         "poetry-source-add",
         "Poetry source successfully added!",
         "Failed to add poetry source.",


### PR DESCRIPTION
swap "default" for "primary"

"default" is deprecated:
https://python-poetry.org/docs/repositories/#default-package-source-deprecated