### PR TITLE
Add no_kernel argument to ssb-project build

### DIFF
--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -18,8 +18,8 @@ from .settings import GITHUB_ORG_NAME
 from .settings import HOME_PATH
 from .settings import STAT_TEMPLATE_DEFAULT_REFERENCE
 from .settings import STAT_TEMPLATE_REPO_URL
-
 from .util import handle_no_kernel_argument
+
 
 # Don't print with color, it's difficult to read when run in Jupyter
 typer.rich_utils.STYLE_OPTION = ""

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -19,6 +19,7 @@ from .settings import HOME_PATH
 from .settings import STAT_TEMPLATE_DEFAULT_REFERENCE
 from .settings import STAT_TEMPLATE_REPO_URL
 
+from .util import handle_no_kernel_argument
 
 # Don't print with color, it's difficult to read when run in Jupyter
 typer.rich_utils.STYLE_OPTION = ""
@@ -107,7 +108,7 @@ def create(  # noqa: C901, S107
         template_git_url,
         checkout,
         verify_config,
-        no_kernel,
+        handle_no_kernel_argument(no_kernel),
     )
 
 
@@ -123,6 +124,13 @@ def build(
         help="Verify git configuration files. Use --no-verify to disable verification (defaults to True).",
         show_default=True,
     ),
+    no_kernel: Annotated[
+        bool,
+        typer.Option(
+            "--no-kernel",
+            help="Do not install a kernel after the project is built (defaults to False).",
+        ),
+    ] = False,
 ) -> None:
     """:wrench:  Create a virtual environment and corresponding Jupyter kernel. Runs in the current folder if no arguments are supplied."""
     build_project(
@@ -131,6 +139,7 @@ def build(
         STAT_TEMPLATE_REPO_URL,
         STAT_TEMPLATE_DEFAULT_REFERENCE,
         verify_config,
+        handle_no_kernel_argument(no_kernel),
     )
 
 

--- a/src/ssb_project_cli/ssb_project/util.py
+++ b/src/ssb_project_cli/ssb_project/util.py
@@ -173,8 +173,10 @@ def get_project_name_and_root_path(
 
 
 def handle_no_kernel_argument(no_kernel: bool) -> bool:
-    """Handle the 'no_kernel' parameter and environment variable. The CLI flag is always prioritised,
-    otherwise it falls back to the environment variable and then lastly defaults to False.
+    """Handle the 'no_kernel' parameter and environment variable.
+
+    The CLI flag is always prioritised, otherwise it falls back to the environment
+    variable and then lastly defaults to False.
     """
     if no_kernel:
         return no_kernel

--- a/src/ssb_project_cli/ssb_project/util.py
+++ b/src/ssb_project_cli/ssb_project/util.py
@@ -16,7 +16,6 @@ from rich import print
 
 from .settings import HOME_PATH
 
-
 kernelspec_manager = jupyter_client.kernelspec.KernelSpecManager()
 
 
@@ -170,3 +169,24 @@ def get_project_name_and_root_path(
                     # Final fall back to project root directory name
                     return path.name, path
     return None, None
+
+
+def handle_no_kernel_argument(no_kernel: bool) -> bool:
+    """Handle the 'no_kernel' parameter and environment variable. The CLI flag is always prioritised,
+    otherwise it falls back to the environment variable and then lastly defaults to False.
+    """
+    if no_kernel:
+        return no_kernel
+    env_var_no_kernel = os.environ.get("NO_KERNEL")
+    if env_var_no_kernel is None:  # handle NO_KERNEL is undefined case
+        return False
+    elif env_var_no_kernel not in ["True", "False"]:
+        print(
+            f"""
+              The value of the 'NO_KERNEL' environment variable is {os.environ["NO_KERNEL"]}.
+              The only valid values are True and False.
+            """
+        )
+        exit(1)
+    else:
+        return bool(env_var_no_kernel)

--- a/src/ssb_project_cli/ssb_project/util.py
+++ b/src/ssb_project_cli/ssb_project/util.py
@@ -16,6 +16,7 @@ from rich import print
 
 from .settings import HOME_PATH
 
+
 kernelspec_manager = jupyter_client.kernelspec.KernelSpecManager()
 
 


### PR DESCRIPTION
Expose the no_kernel argument to the `build` command. Now also supports reading from the environment variable NO_KERNEL for both `create` and `build` commands.