### PR TITLE
ssb-project create: support name and email args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-project-cli"
-version = "1.4.3"
+version = "1.4.4"
 description = "SSB Project CLI"
 authors = ["Statistics Norway <stat-dev@ssb.no>"]
 license = "MIT"

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -85,10 +85,10 @@ def create(  # noqa: C901, S107
         ),
     ] = None,
     name: Annotated[
-        str, typer.Option("--name", help="Project author's full name.")
+        t.Optional[str], typer.Option("--name", help="Project author's full name.")
     ] = None,
     email: Annotated[
-        str, typer.Option("--email", help="Project author's email.")
+        t.Optional[str], typer.Option("--email", help="Project author's email.")
     ] = None,
     no_kernel: Annotated[
         bool,

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -84,6 +84,12 @@ def create(  # noqa: C901, S107
             help="The git reference to check against. Supports branches, tags and commit hashes.",
         ),
     ] = None,
+    name: Annotated[
+        str, typer.Option("--name", help="Project author's full name.")
+    ] = None,
+    email: Annotated[
+        str, typer.Option("--email", help="Project author's email.")
+    ] = None,
     no_kernel: Annotated[
         bool,
         typer.Option(
@@ -107,6 +113,8 @@ def create(  # noqa: C901, S107
         GITHUB_ORG_NAME,
         template_git_url,
         checkout,
+        name,
+        email,
         verify_config,
         handle_no_kernel_argument(no_kernel),
     )

--- a/src/ssb_project_cli/ssb_project/create/create.py
+++ b/src/ssb_project_cli/ssb_project/create/create.py
@@ -36,6 +36,8 @@ def create_project(  # noqa: C901
     github_org_name: str,
     template_repo_url: str,
     checkout: str | None,
+    name: str | None,
+    email: str | None,
     verify_config: bool = True,
     no_kernel: bool = False,
 ) -> None:
@@ -52,6 +54,8 @@ def create_project(  # noqa: C901
         github_org_name: Name of GitHub organization
         template_repo_url: The Cookiecutter template URI.
         checkout: The git reference to check against. Supports branches, tags and commit hashes.
+        name: The project author's name (optional).
+        email: The project author's email (optional).
         verify_config: Determines if gitconfig is verified.
         no_kernel: Determines if a kernel shall be generated or not.
     """
@@ -101,6 +105,8 @@ def create_project(  # noqa: C901
             template_repo_url,
             checkout,
             working_directory,
+            name=name,
+            email=email,
         )
         build_project(
             project_directory,

--- a/tests/unit/create_test/test_create.py
+++ b/tests/unit/create_test/test_create.py
@@ -44,6 +44,8 @@ class TestCreateFunction(TestCase):
             False,
             "",
             None,
+            None,
+            None,
             False,
         )
         assert mock_rmtree.call_count == 0
@@ -66,6 +68,8 @@ class TestCreateFunction(TestCase):
             "github_token",
             False,
             STAT_TEMPLATE_REPO_URL,
+            None,
+            None,
             None,
             False,
         )
@@ -91,6 +95,8 @@ class TestCreateFunction(TestCase):
                 "github_token",
                 False,
                 "",
+                None,
+                None,
                 None,
                 False,
             )
@@ -118,6 +124,8 @@ class TestCreateFunction(TestCase):
                 False,
                 "",
                 None,
+                None,
+                None,
                 False,
             )
         assert mock_rmtree.call_count == 1
@@ -140,6 +148,8 @@ class TestCreateFunction(TestCase):
             "github_token",
             False,
             "https://github.com/statisticsnorway/ssb-minimal-template",
+            None,
+            None,
             None,
             False,
         )
@@ -170,6 +180,8 @@ class TestCreateFunction(TestCase):
                 False,
                 "",
                 None,
+                None,
+                None,
                 False,
             )
 
@@ -191,6 +203,8 @@ def test_project_dir_exists(mock_path_exists: Mock) -> None:
             False,
             "",
             None,
+            None,
+            None,
             False,
         )
     assert excinfo.value.code == 1
@@ -208,7 +222,7 @@ def test_is_valid_project_name() -> None:
 
 @patch("ssb_project_cli.ssb_project.app.create_project", return_value=None)
 def test_default_options_and_types(mock_create_project: Mock) -> None:
-    """Check default options andt types retuned by the create typer CLI command."""
+    """Check default options and types retuned by the create typer CLI command."""
     # Check when all optional parameters are given
     create(
         "test_project",
@@ -219,26 +233,28 @@ def test_default_options_and_types(mock_create_project: Mock) -> None:
         False,
         "",
         None,
+        None,
+        None,
         False,
     )
     assert mock_create_project.call_count == 1
     args, _ = mock_create_project.call_args
-    assert len(args) == 12
-    no_kernel = args[11]
+    assert len(args) == 14
+    no_kernel = args[13]
     assert isinstance(no_kernel, bool) and not no_kernel
 
     # Only mandatory parameters given, check default values and types of optional parameters.
     create("test_project", "description", RepoPrivacy.internal)
     assert mock_create_project.call_count == 2
     args, _ = mock_create_project.call_args
-    assert len(args) == 12
+    assert len(args) == 14
 
     add_github = args[3]
     github_token = args[4]
-    verify_config = args[10]
+    verify_config = args[12]
     template_repo_url = args[8]
     checkout = args[9]
-    no_kernel = args[11]
+    no_kernel = args[13]
     print(f"\ncheckout has type {type(checkout)} with content {checkout}")
     assert (
         isinstance(add_github, bool) and not add_github


### PR DESCRIPTION
You can now pass `--name` and `--email` instead of typing them interactively. This is useful when calling `ssb-project` programatically.