### PR TITLE
Remove publishing to test.pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,6 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
 
-      - name: Publish package on TestPyPI
-        if: "! steps.check-version.outputs.tag"
-        uses: pypa/gh-action-pypi-publish@v1.9.0
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5.25.0
         with:


### PR DESCRIPTION
 This project is using an old cookiecutter template, until now this stop-gap is removing publishing to testpypi for releasing to continue