### PR TITLE
Fix --no-verify flag

### DIFF
--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -13,14 +13,13 @@ from .build.build import build_project
 from .clean.clean import clean_project
 from .create.create import create_project
 from .create.repo_privacy import RepoPrivacy
-from .settings import (
-    CURRENT_WORKING_DIRECTORY,
-    GITHUB_ORG_NAME,
-    HOME_PATH,
-    STAT_TEMPLATE_DEFAULT_REFERENCE,
-    STAT_TEMPLATE_REPO_URL,
-)
+from .settings import CURRENT_WORKING_DIRECTORY
+from .settings import GITHUB_ORG_NAME
+from .settings import HOME_PATH
+from .settings import STAT_TEMPLATE_DEFAULT_REFERENCE
+from .settings import STAT_TEMPLATE_REPO_URL
 from .util import handle_no_kernel_argument
+
 
 # Don't print with color, it's difficult to read when run in Jupyter
 typer.rich_utils.STYLE_OPTION = ""

--- a/src/ssb_project_cli/ssb_project/app.py
+++ b/src/ssb_project_cli/ssb_project/app.py
@@ -13,13 +13,14 @@ from .build.build import build_project
 from .clean.clean import clean_project
 from .create.create import create_project
 from .create.repo_privacy import RepoPrivacy
-from .settings import CURRENT_WORKING_DIRECTORY
-from .settings import GITHUB_ORG_NAME
-from .settings import HOME_PATH
-from .settings import STAT_TEMPLATE_DEFAULT_REFERENCE
-from .settings import STAT_TEMPLATE_REPO_URL
+from .settings import (
+    CURRENT_WORKING_DIRECTORY,
+    GITHUB_ORG_NAME,
+    HOME_PATH,
+    STAT_TEMPLATE_DEFAULT_REFERENCE,
+    STAT_TEMPLATE_REPO_URL,
+)
 from .util import handle_no_kernel_argument
-
 
 # Don't print with color, it's difficult to read when run in Jupyter
 typer.rich_utils.STYLE_OPTION = ""
@@ -68,13 +69,13 @@ def create(  # noqa: C901, S107
             help="Your Github Personal Access Token, follow these instructions to create one: https://manual.dapla.ssb.no/git-github.html#personal-access-token-pat"
         ),
     ] = "",
-    verify_config: Annotated[
+    no_verify: Annotated[
         bool,
         typer.Option(
             "--no-verify",
-            help="Verify git configuration files. Use --no-verify to disable verification (defaults to True).",
+            help="Disable verification of git configuration files.",
         ),
-    ] = True,
+    ] = False,
     template_git_url: Annotated[
         str, typer.Option(help="The Cookiecutter template URI.")
     ] = STAT_TEMPLATE_REPO_URL,
@@ -115,7 +116,7 @@ def create(  # noqa: C901, S107
         checkout,
         name,
         email,
-        verify_config,
+        not no_verify,
         handle_no_kernel_argument(no_kernel),
     )
 
@@ -126,12 +127,13 @@ def build(
         None,
         help="Project path",
     ),
-    verify_config: bool = typer.Option(  # noqa: B008
-        True,
-        "--no-verify",
-        help="Verify git configuration files. Use --no-verify to disable verification (defaults to True).",
-        show_default=True,
-    ),
+    no_verify: Annotated[
+        bool,
+        typer.Option(
+            "--no-verify",
+            help="Disable verification of git configuration files.",
+        ),
+    ] = False,
     no_kernel: Annotated[
         bool,
         typer.Option(
@@ -146,7 +148,7 @@ def build(
         CURRENT_WORKING_DIRECTORY,
         STAT_TEMPLATE_REPO_URL,
         STAT_TEMPLATE_DEFAULT_REFERENCE,
-        verify_config,
+        not no_verify,
         handle_no_kernel_argument(no_kernel),
     )
 

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -12,6 +12,7 @@ from typer.testing import CliRunner
 from ssb_project_cli.ssb_project.app import app
 from ssb_project_cli.ssb_project.util import get_kernels_dict
 
+
 runner = CliRunner()
 
 

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -12,7 +12,6 @@ from typer.testing import CliRunner
 from ssb_project_cli.ssb_project.app import app
 from ssb_project_cli.ssb_project.util import get_kernels_dict
 
-
 runner = CliRunner()
 
 
@@ -26,7 +25,7 @@ def create_project(
     )
     yield result
     # Clean up project directory
-    shutil.rmtree(name)
+    shutil.rmtree(name, ignore_errors=True)
     # Clean up project kernel
     subprocess.run(f"jupyter kernelspec remove -f {name}".split(" "))
 
@@ -48,4 +47,4 @@ def test_create_project_files_created(
 
 def test_create_kernel_installed(name: Path, create_project: Result) -> None:
     """Kernel successfully installed."""
-    assert str(name) in get_kernels_dict()
+    assert str(name) in get_kernels_dict().keys()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,65 @@
+"""Tests that the Arguments and Options in the CLI layer are correctly interpreted."""
+
+from pathlib import Path
+from unittest.mock import ANY
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ssb_project_cli.ssb_project.app import app
+
+
+APP = "ssb_project_cli.ssb_project.app"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@patch(f"{APP}.create_project", return_value=None)
+def test_create_no_verify(
+    mock_create_project: Mock, runner: CliRunner, name: Path
+) -> None:
+    runner.invoke(app, ["create", str(name), "--no-verify"], catch_exceptions=False)
+    mock_create_project.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        False,
+        ANY,
+    )
+
+
+@patch(f"{APP}.create_project", return_value=None)
+def test_create_verify(
+    mock_create_project: Mock, runner: CliRunner, name: Path
+) -> None:
+    runner.invoke(app, ["create", str(name)], catch_exceptions=False)
+    mock_create_project.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        True,
+        ANY,
+    )


### PR DESCRIPTION
The implementation of --no-verify for the create command was such that
the flag had no effect. Invert the logic of the flag such that its
presence actually disables verification.
